### PR TITLE
Fix search for adverts, allow to choose select in dropdowns, add validation for empty email

### DIFF
--- a/db/adverts.go
+++ b/db/adverts.go
@@ -439,12 +439,13 @@ func (s Storage) SearchAdverts(f models.SearchAdvertsFilter, t board.AdvertType,
 		`INNER JOIN Users u ON a.Author = u.Id ` +
 		`WHERE ` +
 		`a.Type = ` + typeString + ` AND a.ExpiredAt > "` + timeString + `" AND a.IsDeleted = 0 ` +
-		`AND (:TradeCashInPerson = 0 OR a.TradeCashInPerson = :TradeCashInPerson) ` +
-		`AND (:TradeCashByMail = 0 OR a.TradeCashByMail = :TradeCashByMail) ` +
-		`AND (:TradeMoneyOrderByMail = 0 OR a.TradeMoneyOrderByMail = :TradeMoneyOrderByMail) ` +
-		`AND (:TradeOther = 0 OR a.TradeOther = :TradeOther) ` +
+		`AND ( (:TradeCashInPerson = 0 AND :TradeCashByMail = 0 AND :TradeMoneyOrderByMail = 0 AND :TradeOther = 0)` +
+		`OR (:TradeCashInPerson != 0 AND a.TradeCashInPerson = :TradeCashInPerson) ` +
+		`OR (:TradeCashByMail != 0 AND a.TradeCashByMail = :TradeCashByMail) ` +
+		`OR (:TradeMoneyOrderByMail != 0 AND a.TradeMoneyOrderByMail = :TradeMoneyOrderByMail) ` +
+		`OR (:TradeOther != 0 AND a.TradeOther = :TradeOther)) ` +
 		`AND (:CountryCode = "" OR a.CountryCode = :CountryCode) ` +
-		`AND (:StateCode = 0 OR a.StateCode = :StateCode) ` +
+		`AND (:StateCode = "" OR a.StateCode = :StateCode) ` +
 		`AND (:City = "" OR LOWER(a.City) LIKE :City) ` +
 		`AND (:Amount = 0 OR a.AmountFrom = :Amount OR :Amount BETWEEN a.AmountFrom AND a.AmountTo) ` +
 		`AND (:Currency = "" OR a.Currency = :Currency) ` +

--- a/web/src/components/layout/Form/ControlDropdown.js
+++ b/web/src/components/layout/Form/ControlDropdown.js
@@ -46,9 +46,9 @@ const Select = styled.select`
 `;
 
 const ControlDropdown = ({ name, options, onChange, error, input, disabled, bg, color }) =>
-    <SelectWrapper>
-        <Select name={name} value={input && input.value} onChange={onChange} error={error} disabled={disabled} bg={bg} color={color}>
-            <option value="" disabled>Select</option>
+      <SelectWrapper>
+        <Select name={name} value={input ? input.value : ""} onChange={onChange} error={error} disabled={disabled} bg={bg} color={color}>
+            <option value="">Select</option>
             {options.map((item, i) => <option value={item.value} key={i}>{item.text}</option>)}
         </Select>
     </SelectWrapper>;

--- a/web/src/components/routes/ForgotPassword/ForgotPassword.js
+++ b/web/src/components/routes/ForgotPassword/ForgotPassword.js
@@ -15,6 +15,7 @@ import { required } from 'validation/rules';
 import { resetPassword } from './actions';
 
 const r = required();
+const emailRequired = (value) => value === 0 || value ? undefined : "Email field can't be blank";
 
 const ForgotPasswordForm = reduxForm({
     form: 'forgotPasswordForm',
@@ -36,7 +37,7 @@ const ForgotPasswordForm = reduxForm({
         return (
             <Form onSubmit={handleSubmit}>
                 <Box width={[1, 1, 1 / 2]}>
-                    <Field name="email" component={FormInput} type="email" label="Email" placeholder="Email" />
+                    <Field name="email"  validate={[emailRequired]} component={FormInput} type="email" label="Email" placeholder="Email" isRequired />
                     <Field name="recaptcha" component={FormCaptcha} validate={[r]} withRef ref={r => { this.recaptchaField = r }} isRequired />
                 </Box>
 


### PR DESCRIPTION
1. Fix search for adverts: by states and by types of payment
2. Allow users to choose "Select" in dropdowns (e.g. Countries and States dropdowns)
3. Add validation for empty email field ("Email field can't be blank") on the Forgot password page