### PR TITLE
Fix saving of Percentage adjustment & Fix loading of spinner & Fix text inputs & Use distance units settings & Add confirmation message after sending a feedback

### DIFF
--- a/web/src/components/layout/Form/ControlInput.js
+++ b/web/src/components/layout/Form/ControlInput.js
@@ -7,6 +7,7 @@ const ControlInput = styled.input`
     padding: ${props => props.theme.space[1]}px ${props => props.theme.space[2]}px;
     border-width: 1px;
     border-style: solid;
+    line-height: ${props => props.theme.controlHeight}px;
     border-color: ${props => getBorderColor(props)};
     background: transparent;
     font-family: ${props => props.theme.fontLight};

--- a/web/src/components/layout/Form/FormDropdownInput.js
+++ b/web/src/components/layout/Form/FormDropdownInput.js
@@ -20,9 +20,9 @@ class FormDropdownInput extends React.Component {
     }
 
     render() {
-        const { label, type, min, max, step, description, isRequired, options, input: { name, value }, meta: { error, warning, touched } } = this.props;
+        const { label, type, min, max, step, description, isRequired, options, defaultUnits, input: { name, value }, meta: { error, warning, touched } } = this.props;
         const showError = !!(touched && (error || warning));
-
+        const unit = defaultUnits ? defaultUnits : '';
         return (
             <FormItem name={name} label={label} isRequired={isRequired} description={description} showError={showError} error={error}>
                 <Flex>
@@ -34,7 +34,7 @@ class FormDropdownInput extends React.Component {
                             name={`${name}_input_options`}
                             options={options}
                             value={value ? value.prefix : ''}
-                            input={{ value: value ? value.prefix : '' }}
+                            input={{ value: value ? value.prefix : unit }}
                             onChange={this.onChangeDropdownValue}
                             error={showError} />
                     </Box>

--- a/web/src/components/layout/Form/FormTextArea.js
+++ b/web/src/components/layout/Form/FormTextArea.js
@@ -6,7 +6,7 @@ import FormItem from './FormItem';
 import { Tip } from '../Text';
 import TextArea from '../TextArea';
 
-const textAreaStyles = { height: 100 };
+const textAreaStyles = { height: 100, backgroundColor: 'transparent' };
 
 const FormTextArea = ({ label, tip, isRequired, description, placeholder, meta: { touched, error, warning }, input: { name, value, onChange } }) => {
     const showError = !!(touched && (error || warning));

--- a/web/src/components/layout/Spinner/Spinner.js
+++ b/web/src/components/layout/Spinner/Spinner.js
@@ -1,16 +1,45 @@
 import React from 'react';
 import './spinner.css'
 
-export default () => (
-    <div className="sk-cube-grid">
-        <div className="sk-cube sk-cube1"></div>
-        <div className="sk-cube sk-cube2"></div>
-        <div className="sk-cube sk-cube3"></div>
-        <div className="sk-cube sk-cube4"></div>
-        <div className="sk-cube sk-cube5"></div>
-        <div className="sk-cube sk-cube6"></div>
-        <div className="sk-cube sk-cube7"></div>
-        <div className="sk-cube sk-cube8"></div>
-        <div className="sk-cube sk-cube9"></div>
-    </div>
-);
+class Spinner extends React.Component{ 
+    constructor(props) {
+        super(props);
+        this.enableSpinner = this.enableSpinner.bind(this);
+
+        this.state = {
+            displaySpinner: false,
+        };
+
+        this.timer = setTimeout(this.enableSpinner, 200);
+    }
+
+    componentWillUnmount() {
+        clearTimeout(this.timer);
+    }
+    
+    enableSpinner() {
+        this.setState({displaySpinner: true});
+    }
+    
+    render() {
+        const {displaySpinner} = this.state;
+    
+        if (!displaySpinner) {
+          return null;
+        }
+    
+        return (<div className="sk-cube-grid">
+                <div className="sk-cube sk-cube1"></div>
+                <div className="sk-cube sk-cube2"></div>
+                <div className="sk-cube sk-cube3"></div>
+                <div className="sk-cube sk-cube4"></div>
+                <div className="sk-cube sk-cube5"></div>
+                <div className="sk-cube sk-cube6"></div>
+                <div className="sk-cube sk-cube7"></div>
+                <div className="sk-cube sk-cube8"></div>
+                <div className="sk-cube sk-cube9"></div>
+                </div>);
+    }
+}
+
+export default Spinner;

--- a/web/src/components/routes/AdvertDetails/AdvertDetails.js
+++ b/web/src/components/routes/AdvertDetails/AdvertDetails.js
@@ -17,6 +17,7 @@ import Messages from './Messages';
 import {
     requestAdvertDetails,
 } from './actions';
+import { Decimal } from 'decimal.js-light';
 
 
 const PanelBody = styled(Box)`
@@ -171,7 +172,7 @@ export const AdvertSummary = ({ details, countries, states, skyPrices }) => (
                 </PositionRow>
                 <SummaryPosition
                     name="Will sell:">
-                    <Focused>{advertValueToString(details.amountFrom, details.amountTo)} SKY</Focused>
+                    <Focused>{advertValueToString(details.amountFrom ? details.amountFrom : new Decimal(0), details.amountTo)} SKY</Focused>
                 </SummaryPosition>
                 <SummaryPosition
                     name="Which is approximately:">

--- a/web/src/components/routes/AdvertDetails/Messages/Messages.js
+++ b/web/src/components/routes/AdvertDetails/Messages/Messages.js
@@ -16,7 +16,9 @@ import {
     getMessagesAuthors,
     selectAuthor,
     markMessageAsRead,
+     clearData, 
 } from './actions';
+
 
 const MessageInput = styled(TextArea) `
     font-size: ${props => props.theme.fontSizes[1]}px;
@@ -154,7 +156,7 @@ const MessageCount = ({ author }) =>
     </MessagesInfo>
 
 const Author = ({ backToUsers, selectedAuthor, messages, userInfo, allMessagesVisible, showAllMessages }) => {
-    const isMoreLinkShown = messages && messages.length != 0 && allMessagesVisible;
+    const isMoreLinkShown = messages && messages.length != 0 && !allMessagesVisible;
     return (<AuthorInfo mt={[2, 0, 0]}>
         {selectedAuthor
             && <BackLink onClick={backToUsers}>
@@ -463,6 +465,7 @@ export default connect(
         getMessagesAuthors,
         selectAuthor,
         markMessageAsRead,
+        clearData,
     }
 )(
     class extends React.Component {
@@ -481,6 +484,11 @@ export default connect(
                 this.readMessages(messages);
             }
         }
+
+        componentWillUnmount(){
+            this.props.clearData();
+        }
+
         readMessages = messages => {
             const { userInfo, markMessageAsRead } = this.props;
             if (messages.length <= 5) {

--- a/web/src/components/routes/AdvertDetails/Messages/actions.js
+++ b/web/src/components/routes/AdvertDetails/Messages/actions.js
@@ -54,3 +54,9 @@ export const markMessageAsRead = messageId => async dispatch => {
 
     dispatch({ type: MARK_MESSAGE_AS_READ_RESPONSE, message: response.data });
 };
+
+export const UNMOUNTING_REQUESTED = 'UNMOUNTING_REQUESTED';
+
+export const clearData = () => dispatch => {
+    dispatch({type: UNMOUNTING_REQUESTED});
+}

--- a/web/src/components/routes/AdvertDetails/Messages/reducers.js
+++ b/web/src/components/routes/AdvertDetails/Messages/reducers.js
@@ -7,6 +7,7 @@ import {
     GET_MESSAGES_RESPONSE,
     GET_MESSAGES_AUTHORS_RESPONSE,
     SELECT_AUTHOR,
+    UNMOUNTING_REQUESTED
 } from './actions';
 
 import { LOGOUT_USER } from 'components/routes/Login/actions';
@@ -36,6 +37,8 @@ export default (state = initialState, action) => {
         case SELECT_AUTHOR:
             return { ...state, selectedAuthor: action.author, state: messageStates.messages };
         case LOGOUT_USER:
+            return initialState;
+        case UNMOUNTING_REQUESTED:
             return initialState;
         default:
             return state;

--- a/web/src/components/routes/AdvertDetails/reducers.js
+++ b/web/src/components/routes/AdvertDetails/reducers.js
@@ -5,14 +5,12 @@ import {
     GET_ADVERT_DETAILS_RESPONSE,
 } from './actions';
 
-export const initialState = {
-    loading: true,
-};
+export const initialState = {};
 
 export default (state = initialState, action) => {
     switch (action.type) {
         case GET_ADVERT_DETAILS_REQUEST:
-            return initialState;
+            return { ...state, loading: true, };
         case GET_ADVERT_DETAILS_RESPONSE:
             return { ...state, ...action.details, loading: false, };
         case LOCATION_CHANGE:

--- a/web/src/components/routes/AdvertDetails/reducers.test.js
+++ b/web/src/components/routes/AdvertDetails/reducers.test.js
@@ -5,8 +5,9 @@ import reduce, { initialState } from './reducers';
 describe('advertDetails reducer', () => {
     describe('GET_ADVERT_DETAILS_REQUEST', () => {
         it('should clear state of reducer', () => {
+            const expectedState = { ...initialState, loading: true, };
             expect(reduce(initialState, { type: actions.GET_ADVERT_DETAILS_REQUEST }))
-                .toEqual(initialState);
+                .toEqual(expectedState);
         });
     });
 

--- a/web/src/components/routes/ContactUs/ContactUs.js
+++ b/web/src/components/routes/ContactUs/ContactUs.js
@@ -6,22 +6,36 @@ import { Helmet } from 'react-helmet';
 import { getPageTitle } from 'utils';
 import Container from 'components/layout/Container';
 import { H2 } from 'components/layout/Text';
-
 import ContactUsForm from './ContactUsForm';
 import { submitFeedbackForm } from './actions';
+import SuccessConfirm from './SuccessConfirm';
 
 class ContactUs extends React.Component {
+    state = {
+        successConfirmationVisible: false,
+    }
+
+    toggleSuccessConfirmation = () => {
+        this.setState(() => ({
+            successConfirmationVisible: !this.state.successConfirmationVisible
+        }));
+    }
+
     handleSubmit = form => {
-        const { submitFeedbackForm, push } = this.props;
+        const { submitFeedbackForm } = this.props;
 
         return submitFeedbackForm(form)
             .then(() => {
-                push('/');
+                this.toggleSuccessConfirmation();
             });
     }
     render() {
         return (
             <Container flex='1 0 auto' flexDirection="column" py={5}>
+                <SuccessConfirm
+                    isOpen={this.state.successConfirmationVisible}
+                    onClose={this.toggleSuccessConfirmation}
+                />
                 <Helmet><title>{getPageTitle('Contact us')}</title></Helmet>
                 <H2 my={[4, 6]}>Contact us</H2>
                 <ContactUsForm onSubmit={this.handleSubmit} />

--- a/web/src/components/routes/ContactUs/ContactUsForm.js
+++ b/web/src/components/routes/ContactUs/ContactUsForm.js
@@ -9,31 +9,43 @@ import { Submit } from 'components/layout/Button';
 const r = required(v => v);
 const maxLength10K = maxLength(10000);
 
-const ContactUsForm = ({ handleSubmit, pristine, submitting, invalid }) => (
-    <Form onSubmit={handleSubmit}>
-        <Flex flexDirection="column" flexWrap="wrap" alignItems="center" justifyContent="center">
-            <Box w={1} mb={25}>
-                <Flex flexDirection="row" flexWrap="wrap" justifyContent="space-between" mx={-3}>
-                    <Box width={[1, 1 / 2]} px={3}>
-                        <Field name="name" component={FormInput} isRequired validate={[r]} type="text" label="Name" placeholder="Name" />
+class ContactUsForm extends React.Component { 
+    componentDidUpdate(prevProps, prevState) {
+        // Reset captcha after receiving response
+        if (prevProps.submitting && prevProps.submitting !== this.props.submitting) {
+            const cptCmp = this.recaptchaField.getRenderedComponent();
+            cptCmp.resetRecaptcha();
+        }
+    }
+
+    render() {
+        const { handleSubmit, pristine, submitting, invalid } = this.props;
+        return (<Form onSubmit={handleSubmit}>
+                <Flex flexDirection="column" flexWrap="wrap" alignItems="center" justifyContent="center">
+                    <Box w={1} mb={25}>
+                        <Flex flexDirection="row" flexWrap="wrap" justifyContent="space-between" mx={-3}>
+                            <Box width={[1, 1 / 2]} px={3}>
+                                <Field name="name" component={FormInput} isRequired validate={[r]} type="text" label="Name" placeholder="Name" />
+                            </Box>
+                            <Box width={[1, 1 / 2]} px={3}>
+                                <Field name="email" component={FormInput} isRequired validate={[r, email]} type="email" label="Email" placeholder="Email" />
+                            </Box>
+                        </Flex>
                     </Box>
-                    <Box width={[1, 1 / 2]} px={3}>
-                        <Field name="email" component={FormInput} isRequired validate={[r, email]} type="email" label="Email" placeholder="Email" />
+                    <Box w={1} mb={25}>
+                        <Field name="subject" component={FormInput} type="text" label="Subject" isRequired validate={[r]} placeholder="Type something..." />
                     </Box>
+                    <Box w={1} mb={25} >
+                        <Field name="message" component={FormTextArea} tip="Up to 10,000 characters" isRequired validate={[r, maxLength10K]} label="Message" placeholder="Message" />
+                    </Box>
+                    <Flex justifyContent="center" flexDirection="column">
+                        <Field name="recaptcha" component={FormCaptcha} validate={[r]} withRef ref={r => { this.recaptchaField = r }} isRequired />
+                        <Submit disabled={invalid || pristine || submitting} showSpinner={submitting} text="Send Message" primary />
+                    </Flex>
                 </Flex>
-            </Box>
-            <Box w={1} mb={25}>
-                <Field name="subject" component={FormInput} type="text" label="Subject" isRequired validate={[r]} placeholder="Type something..." />
-            </Box>
-            <Box w={1} mb={25}>
-                <Field name="message" component={FormTextArea} tip="Up to 10,000 characters" isRequired validate={[r, maxLength10K]} label="Message" placeholder="Message" />
-            </Box>
-            <Flex justifyContent="center" flexDirection="column">
-                <Field name="recaptcha" component={FormCaptcha} validate={[r]} withRef ref={r => { this.recaptchaField = r }} isRequired />
-                <Submit disabled={invalid || pristine || submitting} showSpinner={submitting} text="Send Message" primary />
-            </Flex>
-        </Flex>
-    </Form>);
+            </Form>);
+    }
+}
 
 export default reduxForm({
     form: 'contactUsForm'

--- a/web/src/components/routes/ContactUs/SuccessConfirm.js
+++ b/web/src/components/routes/ContactUs/SuccessConfirm.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Flex, Box } from 'grid-styled';
+
+import { Button } from 'components/layout/Button';
+import { ConfirmModal } from 'components/layout/Modal';
+import { H3 } from 'components/layout/Text';
+
+const style = {
+    content: {
+        top: '50%',
+        left: '50%',
+        right: 'auto',
+        bottom: 'auto',
+        marginRight: '-50%',
+        transform: 'translate(-50%, -50%)'
+    }
+};
+
+const Footer = ({ onClose }) => (
+    <Flex justifyContent={'flex-end'}>
+        <Box mr={2}>
+            <Button text={'OK'} onClick={onClose} primary />
+        </Box>
+    </Flex>
+)
+
+const SuccessConfirm = ({ isOpen, onClose }) => {
+    return (
+        <ConfirmModal
+            isOpen={isOpen}
+            style={style}
+            footer={<Footer onClose={onClose} />}>
+            <Box pb={6}>
+                <H3>The information you submitted has been received and we will get back to you shortly.</H3>
+            </Box>
+        </ConfirmModal>
+    );
+};
+
+SuccessConfirm.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired
+};
+
+export default SuccessConfirm;

--- a/web/src/components/routes/ContactUs/actions.js
+++ b/web/src/components/routes/ContactUs/actions.js
@@ -3,5 +3,15 @@ import { sendFeedback } from 'api/index';
 export const SUBMIT_FEEDBACK_FORM = 'SUBMIT_FEEDBACK_FORM';
 export const submitFeedbackForm = feedback => async dispatch => {
     await sendFeedback(feedback);
+    dispatch(destroyForm());
     dispatch({ type: SUBMIT_FEEDBACK_FORM });
 };
+
+const destroyForm = () => ({
+    type: '@@redux-form/DESTROY',
+    meta: {
+        form: [
+            'contactUsForm',
+        ]
+    }
+});

--- a/web/src/components/routes/PostAdvert/FormCoinPriceInput.js
+++ b/web/src/components/routes/PostAdvert/FormCoinPriceInput.js
@@ -61,15 +61,17 @@ const getCurrencies = (skyPrices) => {
 }
 
 class FormCoinPriceInput extends React.Component {
-    componentDidMount() {
+    setInitValue = () => {
         const { input: { onChange } } = this.props;
         onChange({ value: '', type: PriceType.PERCENT, currency: this.props.userCurrency || 'USD' });
     };
+
     componentDidUpdate(prevProps) {
         if (this.props.userCurrency !== prevProps.userCurrency) {
             this.onChangeCurrency(prevProps.userCurrency);
         }
     };
+
     setMode = mode => {
         const { input: { value, onChange } } = this.props;
         onChange({ value: value.value, type: mode, currency: value.currency });
@@ -90,6 +92,9 @@ class FormCoinPriceInput extends React.Component {
         const { isRequired, input: { name, value }, meta: { error, warning, touched }, skyPrices } = this.props;
         const showError = !!(touched && (error || warning));
         const skyPrice = skyPrices[value.currency];
+        if(!value){	
+            this.setInitValue();	
+        }
 
         return (
             <FormItem name={name} label={<Label skyPrice={skyPrice} currency={value.currency} />} isRequired={isRequired} showError={showError} error={error}>

--- a/web/src/components/routes/PostAdvert/PostingForm.js
+++ b/web/src/components/routes/PostAdvert/PostingForm.js
@@ -35,6 +35,7 @@ const PostAdvert = ({
     theForm,
     preview,
     userCurrency,
+    userDistanceUnits,
 }) => {
     return (
         <Form onSubmit={handleSubmit} noValidate>
@@ -82,6 +83,7 @@ const PostAdvert = ({
                         name={'distance'}
                         component={FormDropdownInput}
                         options={DISTANCE_UNITS_OPTIONS}
+                        defaultUnits={userDistanceUnits}
                         parse={(v) => ({ ...v, data: v.data ? parseInt(v.data, 10) : '' })}
                         label={'How far will you travel to trade?'}
                         isRequired

--- a/web/src/components/routes/PostAdvert/index.js
+++ b/web/src/components/routes/PostAdvert/index.js
@@ -47,6 +47,7 @@ class PostAdvert extends React.Component {
                     skyPrices={skyPrices}
                     selectedCurrency={selectedCurrency}
                     userCurrency={userInfo.currency}
+                    userDistanceUnits={userInfo.distanceUnits}
                     enableReinitialize
                 />}
             </Container>


### PR DESCRIPTION
####  1) Issue: percentage adjustment value isn't saved when we go to the buy/sell advert page or go back from the post preview page #50

 Changes:
 - Remove re-initialization of the Percentage adjustment for each mounting. Initialize values only if the 
 value isn't defined. 

####  2) Issue: background task finishes too quickly and the spinner instantly appears and disappears #30. 

Changes: 
- Use of a timer in a spinner component that only displays the spinner after 0.2 milliseconds has passed. Clear messages from the state after unmounting. 

####  3) Issue: Text in input on registration form is "cut" #31 . 

Changes:
- Add line-height property for ControlInput component

####  4) Issue: Post an advert to buy Skycoin does not use settings for distance units #45

Changes:
- Add default units for FormDropdownInput and use user settings for distance units

####  5) Issue: User will be redirected on the home page at once without showing a success message #33

Changes: 
- Add confirmation modal that feedback has been sent.
- Stay on the Contact Us page and clear form and recaptcha after sending the feedback.
![image](https://user-images.githubusercontent.com/20861900/42753412-87106c08-88f9-11e8-9d56-a65fd130651a.png)

