### PR TITLE
change to use gmail, as postfix doesnt work on production. Breaks docker

### DIFF
--- a/cmd/trade/trade.go
+++ b/cmd/trade/trade.go
@@ -41,7 +41,14 @@ func main() {
 	geo := db.NewGeo(sqlDb)
 	messages := db.NewMessages(sqlDb)
 	skycoinPrices := skycoinPrice.NewSkycoinPrices(currencies)
-	mailer := mail.NewPostfixMailer(*mailHost, *mailUsername, *mailPassword, *feedbackAddress, *mailFromAddress, log)
+
+	// SWH: NewPostfixMailer does not work with gmail or vidahost.  It is not correct to hard code external evironment dependencies in source.
+	// A better solution is to have one mail handing client which works with either service based on the settings/paramenters.  E.g. add a param "usetls" or similar.
+	// I have switched it back to useing the original "gmail" smtp handler, which also works for vidahost.  This will break the current postfix docker setup. The solution is to either:
+	//   a) change the docker postfix server to use plain auth (in the postfix server settings)
+	//   b) add features to the existing mail service client code to handle both (e.g. do something different baserd on port, or a new settting)
+	//	mailer := mail.NewPostfixMailer(*mailHost, *mailUsername, *mailPassword, *feedbackAddress, *mailFromAddress, log)
+	mailer := mail.NewGmailMailer(*mailHost, *mailUsername, *mailPassword, *feedbackAddress, *mailFromAddress, log)
 	skycoinPricesInterface := skycoinPrice.Service(skycoinPrices)
 
 	server := trade.NewHTTPServer(*recaptchaSecret, *bindingFlag, storage, users, auth, log, geo, messages, mailer, &skycoinPricesInterface)

--- a/src/mail/gmail.go
+++ b/src/mail/gmail.go
@@ -7,7 +7,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// GmailMailer is a mail service that allows to send emails to gmail service
+// GmailMailer is a mail service that allows to send emails to gmail service (both feedback and forgot password)
+// SWH: this is just a STMP client handler - it should be able to handle any email (not just gmail). It curently works for vidahost or any plain auth server.GmailMailer
+// Also note that this function is "injected" into the httpserver in trade.go.
+// Ideally, there should be one "Mailer", which, based on the mail server parameters in settings, can send to any mail server.
 type GmailMailer struct {
 	MailerInfo
 }


### PR DESCRIPTION
This is a fix for test and live environments to work with our SMTP servers.
This will break our existing docker env. 
To fix docker, we can either change postfix server config to use Plain auth, or make the Mail function work on either based on parameters.